### PR TITLE
Fix index iteration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ test_script:
 - ps: .\build\appveyor-validate.ps1 -Finalize -IncludeCoverage
 
 on_success:
-- ps: .\build\appveyor-build.ps1 -AutoVersion
+- ps: .\build\appveyor-build.ps1 -SkipPublish 
 
 #on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
The command New-PSTGTableIndexTest would create the test files even if there aren't any indexes to process. Fixex #30 