### PR TITLE
replace capital N with lower case n to prevent build warnings

### DIFF
--- a/functions/New-PSTGTableIndexTest.ps1
+++ b/functions/New-PSTGTableIndexTest.ps1
@@ -205,7 +205,7 @@ function New-PSTGTableIndexTest {
                                 ON s.schema_id = t.schema_id
                         WHERE s.name = '$($tableObject.Schema)'
                             AND t.name = '$($tableObject.Name)'
-                            AND ind.Name IS NOT NULL;"
+                            AND ind.name IS NOT NULL;"
 
                     try {
                         $indexes = Invoke-DbaQuery -SqlInstance $SqlInstance -SqlCredential $SqlCredential -Database $Database -Query $query


### PR DESCRIPTION
Hi Sander, 

Hope you don't mind this small "fix". It will replace a capital 'N' in the template and this will prevent build warnings.
![Inkedbuildwarning_LI](https://user-images.githubusercontent.com/28963365/98265319-3da2eb80-1f89-11eb-8890-a108b5816279.jpg)


If you have any questions, please let me know.

Kind regards,
Mark