### PR TITLE
Added database to replace markers in all scripts

### DIFF
--- a/functions/New-PSTGFunctionParameterTest.ps1
+++ b/functions/New-PSTGFunctionParameterTest.ps1
@@ -234,6 +234,7 @@ function New-PSTGFunctionParameterTest {
                     # Replace the markers with the content
                     $script = $script.Replace("___TESTCLASS___", $TestClass)
                     $script = $script.Replace("___TESTNAME___", $testName)
+                    $script = $script.Replace("___DATABASE___", $Database)
                     $script = $script.Replace("___SCHEMA___", $functionObject.Schema)
                     $script = $script.Replace("___NAME___", $functionObject.Name)
                     $script = $script.Replace("___CREATOR___", $creator)

--- a/functions/New-PSTGIndexColumnTest.ps1
+++ b/functions/New-PSTGIndexColumnTest.ps1
@@ -245,6 +245,7 @@ function New-PSTGIndexColumnTest {
                 # Replace the markers with the content
                 $script = $script.Replace("___TESTCLASS___", $TestClass)
                 $script = $script.Replace("___TESTNAME___", $testName)
+                $script = $script.Replace("___DATABASE___", $Database)
                 $script = $script.Replace("___NAME___", $indexObject.Name)
                 $script = $script.Replace("___CREATOR___", $creator)
                 $script = $script.Replace("___DATE___", $date)

--- a/functions/New-PSTGObjectExistenceTest.ps1
+++ b/functions/New-PSTGObjectExistenceTest.ps1
@@ -272,6 +272,7 @@ function New-PSTGObjectExistenceTest {
                 # Replace the markers with the content
                 $script = $script.Replace("___TESTCLASS___", $TestClass)
                 $script = $script.Replace("___TESTNAME___", $testName)
+                $script = $script.Replace("___DATABASE___", $Database)
                 $script = $script.Replace("___OBJECTTYPE___", $($obj.ObjectType).ToLower())
                 $script = $script.Replace("___SCHEMA___", $obj.Schema)
                 $script = $script.Replace("___NAME___", $obj.Name)

--- a/functions/New-PSTGProcedureParameterTest.ps1
+++ b/functions/New-PSTGProcedureParameterTest.ps1
@@ -235,6 +235,7 @@ function New-PSTGProcedureParameterTest {
                     # Replace the markers with the content
                     $script = $script.Replace("___TESTCLASS___", $TestClass)
                     $script = $script.Replace("___TESTNAME___", $testName)
+                    $script = $script.Replace("___DATABASE___", $Database)
                     $script = $script.Replace("___SCHEMA___", $procedureObject.Schema)
                     $script = $script.Replace("___NAME___", $procedureObject.Name)
                     $script = $script.Replace("___CREATOR___", $creator)

--- a/functions/New-PSTGTableColumnTest.ps1
+++ b/functions/New-PSTGTableColumnTest.ps1
@@ -232,6 +232,7 @@ function New-PSTGTableColumnTest {
                 # Replace the markers with the content
                 $script = $script.Replace("___TESTCLASS___", $TestClass)
                 $script = $script.Replace("___TESTNAME___", $testName)
+                $script = $script.Replace("___DATABASE___", $Database)
                 $script = $script.Replace("___SCHEMA___", $tableObject.Schema)
                 $script = $script.Replace("___NAME___", $tableObject.Name)
                 $script = $script.Replace("___CREATOR___", $creator)

--- a/functions/New-PSTGTableConstraintTest.ps1
+++ b/functions/New-PSTGTableConstraintTest.ps1
@@ -228,6 +228,7 @@ function New-PSTGTableConstraintTest {
                 # Replace the markers with the content
                 $script = $script.Replace("___TESTCLASS___", $TestClass)
                 $script = $script.Replace("___TESTNAME___", $testName)
+                $script = $script.Replace("___DATABASE___", $Database)
                 $script = $script.Replace("___SCHEMA___", $object.Schema)
                 $script = $script.Replace("___NAME___", $object.Name)
                 $script = $script.Replace("___CREATOR___", $creator)

--- a/functions/New-PSTGTableIndexTest.ps1
+++ b/functions/New-PSTGTableIndexTest.ps1
@@ -226,6 +226,7 @@ function New-PSTGTableIndexTest {
                     # Replace the markers with the content
                     $script = $script.Replace("___TESTCLASS___", $TestClass)
                     $script = $script.Replace("___TESTNAME___", $testName)
+                    $script = $script.Replace("___DATABASE___", $Database)
                     $script = $script.Replace("___SCHEMA___", $tableObject.Schema)
                     $script = $script.Replace("___NAME___", $tableObject.Name)
                     $script = $script.Replace("___CREATOR___", $creator)

--- a/functions/New-PSTGViewColumnTest.ps1
+++ b/functions/New-PSTGViewColumnTest.ps1
@@ -234,6 +234,7 @@ function New-PSTGViewColumnTest {
                 # Replace the markers with the content
                 $script = $script.Replace("___TESTCLASS___", $TestClass)
                 $script = $script.Replace("___TESTNAME___", $testName)
+                $script = $script.Replace("___DATABASE___", $Database)
                 $script = $script.Replace("___SCHEMA___", $viewObject.Schema)
                 $script = $script.Replace("___NAME___", $viewObject.Name)
                 $script = $script.Replace("___CREATOR___", $creator)


### PR DESCRIPTION
I have added the Database parameter to string replace markers in all scripts - this should help with users such as myself who have a separate Unit Tests database